### PR TITLE
bot.reply already prepends '<nick>: ' to the msg

### DIFF
--- a/plugins/reynir/seen/seen.js
+++ b/plugins/reynir/seen/seen.js
@@ -43,8 +43,7 @@ var Plugin = (function() {
 							   'notice');
 				return;
 			}
-			var msg = from + ': ' +
-				log.from + ' was last seen ' +
+			var msg = log.from + ' was last seen ' +
 				this.moment(log.createdAt).fromNow() + ' saying: ' +
 				log.message;
 			this.bot.reply(from, to, msg);


### PR DESCRIPTION
Fix sending the nick twice.
