### PR TITLE
bot.reply not client.reply

### DIFF
--- a/src/plugins/mocx/version/version.ts
+++ b/src/plugins/mocx/version/version.ts
@@ -15,7 +15,7 @@ export class Plugin {
 	}
 
 	onCommandVersion(from:string, to:string, message:string, args:any) {
-		this.client.reply(from, to, 'Modubot v' + this.bot.version);
+		this.bot.reply(from, to, 'Modubot v' + this.bot.version);
 	}
 
 }


### PR DESCRIPTION
This is fix for the version plugin which spits out the current version of the bot!